### PR TITLE
flush at the end of start() deleted

### DIFF
--- a/Parser.c
+++ b/Parser.c
@@ -32,9 +32,6 @@ void start() {
 	}
 
 	CreateBoard(3, 3, numOfFixed);
-
-	fflush(stdin);
-	fflush(stdout);
 }
 
 typedef enum {


### PR DESCRIPTION
because it makes error while reading the first command